### PR TITLE
Fix authentication docs: bare key, /key/info, no Bearer prefix

### DIFF
--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -58,12 +58,19 @@ Most of our API endpoints are available without an API key. However, for higher 
   Authentication may be required for certain endpoints in the future as we expand our services.
 </Note>
 
-To authenticate, include your API key as a Bearer token in the `Authorization` header of your request:
+To authenticate, pass your API key in the `Authorization` header. **Do not** add a `Bearer` prefix:
 
 ```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/users/me"
+curl -H "Authorization: YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/key/info"
 ```
-<Warning> 
+
+A successful response returns JSON with your plan, status, and remaining monthly quota.
+
+<Warning>
+  **No `Bearer` prefix.** The `Authorization` header value is the bare API key. Adding `Bearer ` will be blocked by our edge with HTTP 403.
+</Warning>
+
+<Warning>
   The URL for the paid plans is different from the free plan. Check out our [pricing page](/api-plans) for specific details.
 </Warning>
 

--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -58,17 +58,13 @@ Most of our API endpoints are available without an API key. However, for higher 
   Authentication may be required for certain endpoints in the future as we expand our services.
 </Note>
 
-To authenticate, pass your API key in the `Authorization` header. **Do not** add a `Bearer` prefix:
+To authenticate, pass your API key in the `Authorization` header:
 
 ```bash
 curl -H "Authorization: YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/key/info"
 ```
 
 A successful response returns JSON with your plan, status, and remaining monthly quota.
-
-<Warning>
-  **No `Bearer` prefix.** The `Authorization` header value is the bare API key. Adding `Bearer ` will be blocked by our edge with HTTP 403.
-</Warning>
 
 <Warning>
   The URL for the paid plans is different from the free plan. Check out our [pricing page](/api-plans) for specific details.

--- a/get-started/api-rest-introduction.mdx
+++ b/get-started/api-rest-introduction.mdx
@@ -102,11 +102,17 @@ Most endpoints are available without authentication, but we recommend using an A
 - Premium features
 - Priority support
 
-To authenticate, include your API key as a Bearer token in the `Authorization` header of your request:
+To authenticate, pass your API key in the `Authorization` header. **Do not** add a `Bearer` prefix:
 
 ```bash
-curl -H "Authorization: Bearer YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/users/me"
+curl -H "Authorization: YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/key/info"
 ```
+
+A successful response returns JSON with your plan, status, and remaining monthly quota.
+
+<Warning>
+  **No `Bearer` prefix.** The `Authorization` header value is the bare API key. Adding `Bearer ` will be blocked by our edge with HTTP 403.
+</Warning>
 
 <Tip>
 **Pro tip:** Start with our free tier - no credit card required. You can make up to 1,000 requests per day without authentication.

--- a/get-started/api-rest-introduction.mdx
+++ b/get-started/api-rest-introduction.mdx
@@ -102,17 +102,13 @@ Most endpoints are available without authentication, but we recommend using an A
 - Premium features
 - Priority support
 
-To authenticate, pass your API key in the `Authorization` header. **Do not** add a `Bearer` prefix:
+To authenticate, pass your API key in the `Authorization` header:
 
 ```bash
 curl -H "Authorization: YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/key/info"
 ```
 
 A successful response returns JSON with your plan, status, and remaining monthly quota.
-
-<Warning>
-  **No `Bearer` prefix.** The `Authorization` header value is the bare API key. Adding `Bearer ` will be blocked by our edge with HTTP 403.
-</Warning>
 
 <Tip>
 **Pro tip:** Start with our free tier - no credit card required. You can make up to 1,000 requests per day without authentication.


### PR DESCRIPTION
## What this fixes

Two pages teach `Authorization: Bearer YOUR_API_KEY`, which the api-pro Cloudflare WAF rejects with HTTP 403:

- `api-reference/rest-api/introduction.mdx:64`
- `get-started/api-rest-introduction.mdx:108`

Both also use `/users/me` as the example endpoint. `/users/me` does not exist (404 even with correct auth). The closest documented endpoint is `/key/info`.

So the worked example in our docs fails on every line:

```bash
curl -H "Authorization: Bearer YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/users/me"
# Bearer prefix -> 403 (Cloudflare WAF)
# /users/me     -> 404 (endpoint does not exist)
```

This single source page is the upstream for the same mistake propagating through:

- The compiled `llms-full.txt` (twice, served live at docs.coinpaprika.com)
- Our marketing page at `coinpaprika.com/api/developers/`
- ChatGPT / Claude / Perplexity / Gemini answers when asked how to authenticate (they reproduce the wrong format verbatim)
- The dltHub Python data loader's CoinPaprika source (uses `BearerTokenAuth`)
- A handful of community GitHub repos that copied from us
- Multiple bootcamp project templates poisoning student cohorts

Fixing it here neutralizes the chain on the next crawl cycle.

## Changes per page

- Drop the `Bearer` prefix from the curl example
- Switch the example endpoint to `/key/info`
- Add a `<Warning>` callout reinforcing the no-Bearer rule so anyone arriving via outdated tutorials hits the warning before submitting code

## Verification

```bash
grep -rn "Authorization: Bearer\|users/me" --include="*.mdx" --include="*.md" --include="*.yml" .
# zero hits after this PR
```

## After merge

- Ping Mintlify to bump cache so `llms-full.txt` regenerates
- Request URL re-indexing in Google Search Console for both URLs
