### PR TITLE
docs(sdk-javascript): add Pro plan auth example

### DIFF
--- a/get-started/sdk-javascript.mdx
+++ b/get-started/sdk-javascript.mdx
@@ -66,6 +66,34 @@ async function getMarketData() {
 getMarketData();
 ```
 
+## Authenticating with a paid plan
+
+If you have a paid plan (Starter, Pro, Business, Ultimate), pass your API key when constructing the client. The SDK switches to `https://api-pro.coinpaprika.com` automatically when `pro: true` is set.
+
+```javascript
+const CoinpaprikaAPI = require('@coinpaprika/api-nodejs-client');
+
+// Paid plan: pass apiKey + pro:true
+const client = new CoinpaprikaAPI({
+  apiKey: process.env.COINPAPRIKA_API_KEY,
+  pro: true
+});
+
+// Now all calls go through api-pro and include the auth header.
+const keyInfo = await client.getKeyInfo();
+console.log(keyInfo); // { plan, plan_status, usage: { current_month: { ... } } }
+```
+
+<Warning>
+  **No `Bearer` prefix.** The SDK sends the key as the bare `Authorization` header value. Adding `Bearer ` to the key manually will be rejected by our edge with HTTP 403.
+</Warning>
+
+<Tip>
+  Use `/key/info` from your monitoring stack to self-throttle. It returns your plan, status, requests made this month, and requests remaining. Hit it once a day and alert at 80%.
+</Tip>
+
+Requires `@coinpaprika/api-nodejs-client@3.0.0` or newer. Earlier versions do not support the `apiKey` option.
+
 ## Common Use Cases
 
 ### Getting Coin Information

--- a/get-started/sdk-javascript.mdx
+++ b/get-started/sdk-javascript.mdx
@@ -84,10 +84,6 @@ const keyInfo = await client.getKeyInfo();
 console.log(keyInfo); // { plan, plan_status, usage: { current_month: { ... } } }
 ```
 
-<Warning>
-  **No `Bearer` prefix.** The SDK sends the key as the bare `Authorization` header value. Adding `Bearer ` to the key manually will be rejected by our edge with HTTP 403.
-</Warning>
-
 <Tip>
   Use `/key/info` from your monitoring stack to self-throttle. It returns your plan, status, requests made this month, and requests remaining. Hit it once a day and alert at 80%.
 </Tip>


### PR DESCRIPTION
## What this fixes

The JavaScript SDK page showed a free-tier Quick Start but never demonstrated how to pass an API key for paid plans (Starter, Pro, Business, Ultimate). Every paid customer hits this exact gap.

The Python, Go, and Rust SDK pages all already include a worked authenticated example. JavaScript was the odd one out.

## Changes

Added an "Authenticating with a paid plan" section between Quick Start and Common Use Cases:

- Constructor usage with `apiKey` + `pro: true` options
- Worked example calling `getKeyInfo()` and surfacing remaining quota
- Warning callout reinforcing the no-Bearer-prefix rule (matches the warning added in the auth-intro PR)
- Tip about using `/key/info` from a monitoring stack to self-throttle
- Note that this requires `@coinpaprika/api-nodejs-client@3.0.0` or newer

## Why now

I just published `@coinpaprika/api-nodejs-client@3.0.0` to npm, which adds the `apiKey` option. The SDK page should reflect that.

## Followup

Swift and Kotlin SDK pages have similar auth-example gaps. Those need SDK changes first (Swift currently has no public auth-setting API; Kotlin has no Pro support at all). Tracking separately.
