### PR TITLE
Normalize changelog version prefix and FAQ WebSocket wording

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -18,31 +18,31 @@ sidebarTitle: Version history
 ## 1.7.7 - 2023.06.07
 - Added official Python client link
 
-## v1.7.6 - 2023.04.12
+## 1.7.6 - 2023.04.12
 - New intervals for OHLCV endpoint
 
-## v1.7.5 - 2022.12.07
+## 1.7.5 - 2022.12.07
 - Removed documentation for /beta/ endpoints
 
-## v1.7.4 - 2022.09.19
+## 1.7.4 - 2022.09.19
 - Key info endpoint
 - Coin logo image URL
 
-## v1.7.3 - 2022.09.08
+## 1.7.3 - 2022.09.08
 - Plans update
 
-## v1.7.2 - 2022.07.22
+## 1.7.2 - 2022.07.22
 - Changelog endpoint documentation
 
-## v1.7.1 - 2022.07.14
+## 1.7.1 - 2022.07.14
 - Beta endpoints documentation
 
-## v1.7.0 - 2022.05.06
+## 1.7.0 - 2022.05.06
 - API-Pro documentation
 
-## v1.6.1 - 2020.12.09
+## 1.6.1 - 2020.12.09
 - Added information about first date with price data for currency ticker /tickers and /tickers/{coin_id}
 - Added redirect for historical tickers by contract address /contracts/{platform_id}/{contract_address}/historical
 
-## v1.6.0 - 2020.10.27
+## 1.6.0 - 2020.10.27
 - Added contracts section /contracts, /contracts/{platform_id}, /contracts/{platform_id}/{contract_address} 

--- a/faq.mdx
+++ b/faq.mdx
@@ -39,8 +39,8 @@ sidebarTitle: "FAQ"
   <Accordion title="How often do prices refresh?">
     Prices from various markets are collected in near real-time. However, the prices available in the REST API have a resolution of up to 10 minutes, up to 3 minutes, or up to 1 minute, depending on your plan. In case you need fresher data, please get in touch with us about our Enterprise solutions.
   </Accordion>
-    <Accordion title="Do you have WebSockets?">
-    Yes, WebSocket protocol is included in the Enterprise plan. Please contact us for details.
+    <Accordion title="Do you have WebSocket support?">
+    Yes, the WebSocket protocol is included in the Enterprise plan. Please contact us for details.
   </Accordion>
   <Accordion title="Are there any rate limits?">
     We have a global limit of 10 requests/second per IP. Other limits on the number of queries are assigned to the corresponding plan and detailed in the documentation. When the limits are reached, the API returns HTTP codes `429` or `402`. You can find the monthly limits for each plan in our [Getting Started guide](/api-reference/introduction#rate-limits).


### PR DESCRIPTION
Two small consistency fixes.

## changelog.mdx

The 5 most recent entries use plain `## 1.7.7 - YYYY.MM.DD`; older entries use `## v1.7.6 - YYYY.MM.DD`. Stripping the `v` from the older entries so the whole file uses the cleaner form. Matches the Keep-a-Changelog style and the direction set by the recent entries.

## faq.mdx

`Do you have WebSockets?` (plural) → `Do you have WebSocket support?` (singular, matches the answer text and W3C spelling).

Both are 1-3 line changes; no content meaning changed.