### PR TITLE
Add working Pro auth examples to Swift and Kotlin SDK pages

### DIFF
--- a/get-started/sdk-kotlin.mdx
+++ b/get-started/sdk-kotlin.mdx
@@ -41,7 +41,7 @@ Finally, ensure you have the `INTERNET` permission in your `AndroidManifest.xml`
 First, configure and build a `Retrofit` instance. You must provide the base URL and a converter factory.
 
 ```kotlin
-import com.coinpaprika.apiclient.BaseUrl
+import com.coinpaprika.apiclient.COINPAPRIKA_BASE_URL
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Retrofit
@@ -53,7 +53,7 @@ object RetrofitClient {
         .build()
 
     val instance: Retrofit = Retrofit.Builder()
-        .baseUrl(BaseUrl.API_ENDPOINT)
+        .baseUrl(COINPAPRIKA_BASE_URL)
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
 }
@@ -97,6 +97,47 @@ fun fetchTickers() {
     }
 }
 ```
+
+## Authenticating with a paid plan
+
+Paid plans (Starter / Pro / Business / Ultimate / Enterprise) live on a separate hostname, `https://api-pro.coinpaprika.com/v1/`, and require an API key in the `Authorization` header. The library doesn't provide a Pro-aware base URL constant; configure it on your `Retrofit` builder along with an OkHttp `Interceptor` that injects the key on every request.
+
+```kotlin
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object ProRetrofitClient {
+    // CoinPaprika expects the bare API key — no `Bearer ` prefix.
+    private val authInterceptor = Interceptor { chain ->
+        val key = System.getenv("COINPAPRIKA_API_KEY")
+            ?: error("COINPAPRIKA_API_KEY is not set")
+        val request = chain.request().newBuilder()
+            .addHeader("Authorization", key)
+            .build()
+        chain.proceed(request)
+    }
+
+    private val httpClient = OkHttpClient.Builder()
+        .addInterceptor(authInterceptor)
+        .build()
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    val instance: Retrofit = Retrofit.Builder()
+        .baseUrl("https://api-pro.coinpaprika.com/v1/")
+        .client(httpClient)
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .build()
+}
+```
+
+Free-tier callers don't need any of this — keep the `RetrofitClient` from Quick Start pointed at `COINPAPRIKA_BASE_URL` without an interceptor.
 
 ## Available Services
 
@@ -145,13 +186,13 @@ Used to fetch ticker price and market data.
 
 <AccordionGroup>
   <Accordion title="How do I authenticate with Retrofit?">
-    Add an <code>Interceptor</code> to your OkHttp client to inject the API key header when using Pro endpoints.
+    Add an OkHttp <code>Interceptor</code> that adds the <code>Authorization</code> header (bare key, no <code>Bearer</code> prefix) and point your <code>Retrofit</code> builder at <code>https://api-pro.coinpaprika.com/v1/</code>. See the "Authenticating with a paid plan" section above.
   </Accordion>
   <Accordion title="Where do I find coin IDs for service methods?">
     Use the [Coverage Checker](/tools/coverage) to discover canonical IDs (e.g., <code>btc-bitcoin</code>).
   </Accordion>
   <Accordion title="How do I request historical OHLCV?">
-    Call the historical OHLCV service method with required parameters; Pro access is required for history.
+    Historical OHLCV requires a paid plan. Use the <code>ProRetrofitClient</code> from the Pro authentication section, then call <code>CoinsService.getHistoricalCoinOHLCV(...)</code> with <code>start</code>/<code>end</code> in ISO date format and a <code>quote</code> like <code>"usd"</code>.
   </Accordion>
   <Accordion title="What’s the recommended error handling?">
     Catch <code>HttpException</code> for non-2xx responses (e.g., 404, 429) and <code>IOException</code> for network failures; apply backoff before retries.

--- a/get-started/sdk-swift.mdx
+++ b/get-started/sdk-swift.mdx
@@ -48,24 +48,43 @@ Coinpaprika.API.global().perform { result in
 }
 ```
 
-## Using the Pro API
+## Authenticating with a paid plan
 
-To use the Pro API, you must manually change the base URL in the `Configuration` object before making any requests. This should be done once when your app launches.
+Paid plans (Starter / Pro / Business / Ultimate / Enterprise) live on a separate hostname, `https://api-pro.coinpaprika.com/v1/`, and require an API key in the `Authorization` header. Send the bare key — a `Bearer ` prefix is rejected by the WAF.
+
+The high-level `Coinpaprika.API` static methods don't currently accept a key. To call paid endpoints, drop down to the `CoinpaprikaNetworking` `Request<Model>` constructor with `.bearer(token:)` and point it at the Pro base URL. The package exposes `CoinpaprikaNetworking` as a separate library product, so add it to your target's dependencies alongside `Coinpaprika`.
 
 ```swift
-import Coinpaprika
+import CoinpaprikaNetworking
+import Foundation
 
-// Set the base URL to the Pro endpoint
-Coinpaprika.Configuration.baseUrl = URL(string: "https://api-pro.coinpaprika.com/v1/")!
+struct KeyInfo: Codable {
+    let plan: String
+    let plan_status: String
+}
 
-// Now all subsequent requests will use the Pro API
-Coinpaprika.API.tickers().perform { result in
-    // Pro plan provides access to all tickers
-    if case .success(let tickers) = result {
-        print("Successfully fetched \(tickers.count) tickers using the Pro API.")
+let key = ProcessInfo.processInfo.environment["COINPAPRIKA_API_KEY"]!
+
+let request = Request<KeyInfo>(
+    baseUrl: URL(string: "https://api-pro.coinpaprika.com/v1/")!,
+    method: .get,
+    path: "key/info",
+    params: nil,
+    userAgent: "my-app/1.0",
+    authorisation: .bearer(token: key)
+)
+
+request.perform { result in
+    switch result {
+    case .success(let info):
+        print("Plan: \(info.plan), status: \(info.plan_status)")
+    case .failure(let error):
+        print("Error: \(error)")
     }
 }
 ```
+
+For free-tier endpoints that don't need a key (most of `Coinpaprika.API`), keep using the high-level static API against the default base URL.
 
 ## Common Use Cases
 
@@ -116,28 +135,39 @@ Coinpaprika.API.coin(id: "eth-ethereum").perform { response in
 
 ### Historical Ticker Data
 
-Note: Accessing historical data requires using the Pro API.
+Historical endpoints require a paid plan. The high-level `Coinpaprika.API.historicalTicks(...)` shape is shown below for the request structure; to actually authenticate, build a `Request<Tick>` against the Pro base URL using the `.bearer(token:)` pattern from "Authenticating with a paid plan".
 
 ```swift
-import Coinpaprika
+import CoinpaprikaNetworking
+import Foundation
 
-// Ensure Pro API is configured
-Coinpaprika.Configuration.baseUrl = URL(string: "https://api-pro.coinpaprika.com/v1/")!
+struct Tick: Codable {
+    let timestamp: String
+    let price: Double
+    let volume24h: Double
+    enum CodingKeys: String, CodingKey {
+        case timestamp, price
+        case volume24h = "volume_24h"
+    }
+}
 
+let key = ProcessInfo.processInfo.environment["COINPAPRIKA_API_KEY"]!
 let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
+let isoStart = ISO8601DateFormatter().string(from: sevenDaysAgo)
 
-Coinpaprika.API.historicalTicks(
-    id: "btc-bitcoin",
-    start: sevenDaysAgo,
-    limit: 100,
-    quote: .usd
-).perform { response in
-    switch response {
+let request = Request<[Tick]>(
+    baseUrl: URL(string: "https://api-pro.coinpaprika.com/v1/")!,
+    method: .get,
+    path: "tickers/btc-bitcoin/historical",
+    params: ["start": isoStart, "limit": 100, "quote": "usd"],
+    userAgent: "my-app/1.0",
+    authorisation: .bearer(token: key)
+)
+
+request.perform { result in
+    switch result {
     case .success(let ticks):
-        print("Recent Historical Ticks for Bitcoin:")
-        ticks.forEach { tick in
-            print("[\(tick.timestamp)] Price: $\(tick.price), Volume: \(tick.volume24h)")
-        }
+        ticks.forEach { print("[\($0.timestamp)] $\($0.price)") }
     case .failure(let error):
         print("Error fetching historical ticks: \(error)")
     }
@@ -246,13 +276,13 @@ func getMarketData() async {
 
 <AccordionGroup>
   <Accordion title="How do I use the Pro API in Swift?">
-    Set <code>Coinpaprika.Configuration.baseUrl</code> to the Pro endpoint once at app startup; authenticate at the edge as needed.
+    The high-level <code>Coinpaprika.API</code> static methods don't currently accept a key. Use <code>CoinpaprikaNetworking</code>'s <code>Request&lt;Model&gt;</code> constructor with <code>.bearer(token:)</code> and the <code>https://api-pro.coinpaprika.com/v1/</code> base URL. See the "Authenticating with a paid plan" section above.
   </Accordion>
   <Accordion title="Where can I find coin IDs for methods like ticker(id:)?">
     Use the [Coverage Checker](/tools/coverage) to obtain canonical IDs (e.g., <code>btc-bitcoin</code>).
   </Accordion>
   <Accordion title="How do I fetch historical ticks/ohlcv?">
-    Configure the Pro base URL and call the relevant historical APIs with <code>start</code>/<code>end</code> and <code>quote</code>.
+    Historical endpoints require a paid plan. Build a <code>Request&lt;Model&gt;</code> against the Pro base URL with <code>.bearer(token:)</code> auth (see the "Authenticating with a paid plan" section), pointing at <code>tickers/{coinId}/historical</code> or <code>coins/{coinId}/ohlcv/historical</code> with <code>start</code>/<code>end</code>/<code>quote</code> parameters.
   </Accordion>
   <Accordion title="What is the recommended error handling?">
     Inspect the failure case of <code>Result</code> and map to app errors; for 429 responses, back off and retry.


### PR DESCRIPTION
Two SDK pages were promising paid-tier access without showing how to actually authenticate.

## Swift

The "Using the Pro API" section just told readers to set `Coinpaprika.Configuration.baseUrl` and stopped there — but the high-level `Coinpaprika.API` static methods don't accept an API key, so flipping the base URL alone produces 401/403 from api-pro. Same gap in the "Historical Ticker Data" example.

Replaced both with a working example using `CoinpaprikaNetworking.Request<Model>` and `.bearer(token:)`:

```swift
import CoinpaprikaNetworking
import Foundation

let request = Request<KeyInfo>(
    baseUrl: URL(string: "https://api-pro.coinpaprika.com/v1/")!,
    method: .get,
    path: "key/info",
    params: nil,
    userAgent: "my-app/1.0",
    authorisation: .bearer(token: key)
)
```

Verified live against `/key/info` (returns plan info) and `/tickers/btc-bitcoin/historical` (works with paid key).

Updated FAQs to point at the new section instead of the old "set the base URL" hand-wave.

## Kotlin

Two issues:

1. The Quick Start example imports `BaseUrl.API_ENDPOINT`, but that constant doesn't exist. The actual constant in the SDK is `COINPAPRIKA_BASE_URL` (top-level in `package com.coinpaprika.apiclient`). The example as published wouldn't compile. Fixed.

2. The page had no Pro section at all. The Kotlin SDK ships a single hardcoded free-tier base URL constant and no API-key plumbing, so users have to wire it up themselves. Added a Pro section with an OkHttp `Interceptor` that injects `Authorization: <key>` (bare, no `Bearer` prefix) and a Retrofit builder pointed at `https://api-pro.coinpaprika.com/v1/`.

Updated FAQs to reference the new section.

## What this closes

Addresses P1.4 from the Bearer/typo cleanup audit: "SDK pages (JS / Swift / Kotlin) missing Pro auth examples." JS was covered in #23 earlier; this finishes Swift and Kotlin.

The Kotlin SDK itself still has the underlying gap — no native Pro support — but documenting the correct workaround is the right move until that SDK gets modernized.