### PR TITLE
SEO: add titles + descriptions to API reference intro and FAQ

### DIFF
--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Getting started'
+title: 'CoinPaprika API reference — crypto prices, market & OHLCV data'
 sidebarTitle: "Introduction"
+description: "REST API reference for crypto market data: real-time prices, market cap, volume, historical OHLCV and exchange data for 50,000+ assets. Free tier, no API key to start."
 ---
 
 The CoinPaprika API provides extensive and reliable data for over 50,000 crypto assets, tracking them across more than 350 exchanges. Below are some of the most popular endpoints to get you started.

--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'CoinPaprika API reference — crypto prices, market & OHLCV data'
 sidebarTitle: "Introduction"
-description: "REST API reference for crypto market data: real-time prices, market cap, volume, historical OHLCV and exchange data for 50,000+ assets. Free tier, no API key to start."
+description: "REST API reference for crypto market data: real-time prices, market cap, volume, historical OHLCV and exchange data for 12,000+ cryptocurrencies. Free tier, no API key to start."
 ---
 
-The CoinPaprika API provides extensive and reliable data for over 50,000 crypto assets, tracking them across more than 350 exchanges. Below are some of the most popular endpoints to get you started.
+The CoinPaprika API provides extensive and reliable data for over 12,000 cryptocurrencies, tracking them across more than 350 exchanges. Below are some of the most popular endpoints to get you started.
 
 <Tip>
   See also: [Coverage Checker](/tools/coverage), [API Plans](/api-plans), [Streaming API](/api-reference/streaming-api/streaming-introduction)

--- a/faq.mdx
+++ b/faq.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Frequently asked questions'
+title: 'CoinPaprika API FAQ — rate limits, free tier & coverage'
 sidebarTitle: "FAQ"
+description: "Answers about the CoinPaprika API: rate limits, free-tier scope, historical data depth, asset and exchange coverage, and commercial use."
 ---
 
 ## General

--- a/get-started/api-rest-introduction.mdx
+++ b/get-started/api-rest-introduction.mdx
@@ -21,7 +21,7 @@ description: "Crypto API for developers: real-time cryptocurrency prices, market
 
 ## Crypto price API and cryptocurrency data API
 
-The CoinPaprika REST API provides comprehensive access to real-time cryptocurrency market data, historical prices, volumes, and market cap for over 50,000 assets across 350+ exchanges.
+The CoinPaprika REST API provides comprehensive access to real-time cryptocurrency market data, historical prices, volumes, and market cap for over 12,000 cryptocurrencies across 350+ exchanges.
 
 Our REST API is designed with developers in mind, offering:
 - **Simple HTTP requests** - Use standard GET, POST methods


### PR DESCRIPTION
Two docs pages rank on page 1 of Google but convert almost nothing, because the prior SEO pass missed them:

- `/api-reference/rest-api/introduction`: **19,346 impressions/yr at position 4.9 — 0.18% CTR**. The title was the generic 'Getting started' with no meta description, so the search snippet gave nobody a reason to click.
- `/faq`: 3,092 impressions/yr, no description.

This adds keyword-targeted titles and descriptions to both (homepage and get-started were already optimized, so they're left alone). Copy is unchanged.

Tracking: coinpaprika/devrel#58. I'll check CTR movement in GSC ~30 days after merge.

Note: I deliberately did **not** touch the '50,000 assets / 350 exchanges' coverage numbers. Live /v1/coins reports ~60k total coins and /v1/global ~12.6k active, so '50,000+' is defensible as a total-tracked figure, but the main site quotes different numbers elsewhere (2,500 / 45k / 48k). Worth settling on one canonical set separately before changing it everywhere.