### PR TITLE
docs: strip em dashes from page titles

### DIFF
--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'CoinPaprika API reference — crypto prices, market & OHLCV data'
+title: 'CoinPaprika API reference: crypto prices, market & OHLCV data'
 sidebarTitle: "Introduction"
 description: "REST API reference for crypto market data: real-time prices, market cap, volume, historical OHLCV and exchange data for 12,000+ cryptocurrencies. Free tier, no API key to start."
 ---

--- a/faq.mdx
+++ b/faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'CoinPaprika API FAQ — rate limits, free tier & coverage'
+title: 'CoinPaprika API FAQ: rate limits, free tier & coverage'
 sidebarTitle: "FAQ"
 description: "Answers about the CoinPaprika API: rate limits, free-tier scope, historical data depth, asset and exchange coverage, and commercial use."
 ---

--- a/get-started/api-rest-introduction.mdx
+++ b/get-started/api-rest-introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'CoinPaprika Crypto API — REST Reference'
+title: 'CoinPaprika Crypto API: REST Reference'
 sidebarTitle: "REST API Reference"
 description: "Crypto API for developers: real-time cryptocurrency prices, market data, and historical data via REST. Build with CoinPaprika's reliable crypto data API."
 ---


### PR DESCRIPTION
House style: no em dashes. Replaces em dashes with colons in the three page titles touched recently (API reference intro, get-started REST reference, FAQ).