### PR TITLE
docs: keyword frontmatter for search visibility (22 pages)

### DIFF
--- a/api-plans.mdx
+++ b/api-plans.mdx
@@ -1,6 +1,7 @@
 ---
 title: "API Plans"
 description: "Explore the different API plans offered by CoinPaprika to suit your needs, from hobbyist to enterprise-level."
+keywords: ["crypto api free", "free crypto api", "commercial use crypto api", "affordable cryptocurrency api", "crypto api pricing", "no key crypto api"]
 ---
 To ensure you can explore our capabilities without commitment, we also provide a **generous free tier**. It's the perfect way to test our data, build out a proof-of-concept, and get to know the full range of our API before upgrading.
 

--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -2,6 +2,7 @@
 title: 'CoinPaprika API reference — crypto prices, market & OHLCV data'
 sidebarTitle: "Introduction"
 description: "REST API reference for crypto market data: real-time prices, market cap, volume, historical OHLCV and exchange data for 12,000+ cryptocurrencies. Free tier, no API key to start."
+keywords: ["crypto api", "crypto price api", "crypto historical price api", "crypto historical data api free", "coinmarketcap api alternative", "market cap api", "crypto volume api"]
 ---
 
 The CoinPaprika API provides extensive and reliable data for over 12,000 cryptocurrencies, tracking them across more than 350 exchanges. Below are some of the most popular endpoints to get you started.

--- a/api-reference/streaming-api/streaming-api-tutorial.mdx
+++ b/api-reference/streaming-api/streaming-api-tutorial.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Your First Crypto Stream in 5 Minutes"
 description: "A step-by-step guide to connecting to the CoinPaprika Streaming API and receiving live ticker data in less than 5 minutes."
+keywords: ["crypto streaming api tutorial", "real-time crypto prices", "sse crypto api", "live crypto price stream"]
 ---
 
 # Your First Crypto Stream in 5 Minutes

--- a/api-reference/streaming-api/streaming-introduction.mdx
+++ b/api-reference/streaming-api/streaming-introduction.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Streaming API Introduction"
 description: "High-frequency cryptocurrency data via WebSocket"
+keywords: ["crypto streaming api", "real-time crypto prices", "sse crypto api", "live crypto price stream", "websocket crypto price"]
 ---
 
 # CoinPaprika Streaming API

--- a/claude-code-plugin.mdx
+++ b/claude-code-plugin.mdx
@@ -2,6 +2,7 @@
 title: "CoinPaprika Claude Code plugin"
 sidebarTitle: "Claude Code Plugin"
 description: "Install the CoinPaprika Claude Code plugin with two commands. Access real-time crypto prices, market data, and exchange information directly in Claude Code."
+keywords: ["coinpaprika claude code", "crypto claude code plugin", "claude crypto data"]
 ---
 
 ## What is the CoinPaprika Claude Code plugin?

--- a/cli.mdx
+++ b/cli.mdx
@@ -2,6 +2,7 @@
 title: "CoinPaprika CLI -- crypto data from your terminal"
 sidebarTitle: "CLI"
 description: "Install the CoinPaprika CLI with one command. Query coin prices, market data, OHLCV history, exchanges, and more from your terminal. Supports macOS, Linux, and Windows."
+keywords: ["coinpaprika cli", "crypto cli", "crypto price cli", "cryptocurrency command line"]
 ---
 
 ## What is the CoinPaprika CLI?

--- a/dexpaprika.mdx
+++ b/dexpaprika.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'On-chain & DEX data'
 sidebarTitle: "Introduction"
+keywords: ["dex api", "on-chain data api", "dexpaprika", "defi data api"]
 ---
 
 ## Introducing DexPaprika

--- a/faq.mdx
+++ b/faq.mdx
@@ -2,6 +2,7 @@
 title: 'CoinPaprika API FAQ — rate limits, free tier & coverage'
 sidebarTitle: "FAQ"
 description: "Answers about the CoinPaprika API: rate limits, free-tier scope, historical data depth, asset and exchange coverage, and commercial use."
+keywords: ["crypto api faq", "coinpaprika api", "crypto api help"]
 ---
 
 ## General

--- a/get-started/api-rest-introduction.mdx
+++ b/get-started/api-rest-introduction.mdx
@@ -2,6 +2,7 @@
 title: 'CoinPaprika Crypto API — REST Reference'
 sidebarTitle: "REST API Reference"
 description: "Crypto API for developers: real-time cryptocurrency prices, market data, and historical data via REST. Build with CoinPaprika's reliable crypto data API."
+keywords: ["crypto api", "crypto rest api", "free crypto api", "crypto price api", "cryptocurrency data api", "get started crypto api"]
 ---
 ## CoinPaprika crypto API overview
 

--- a/get-started/sdk-go.mdx
+++ b/get-started/sdk-go.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Go SDK"
 description: "Official CoinPaprika API Go client library"
+keywords: ["crypto api go", "crypto api golang", "coinpaprika go sdk", "golang crypto data"]
 ---
 
 # CoinPaprika Go SDK

--- a/get-started/sdk-javascript.mdx
+++ b/get-started/sdk-javascript.mdx
@@ -1,6 +1,7 @@
 ---
 title: "JavaScript SDK"
 description: "Official CoinPaprika API Node.js client library"
+keywords: ["crypto api javascript", "crypto api node", "coinpaprika javascript sdk", "js crypto data"]
 ---
 
 # CoinPaprika JavaScript SDK

--- a/get-started/sdk-kotlin.mdx
+++ b/get-started/sdk-kotlin.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Kotlin SDK"
 description: "Official CoinPaprika API Kotlin/Android client building blocks"
+keywords: ["crypto api kotlin", "coinpaprika kotlin sdk", "kotlin crypto data", "android crypto api"]
 ---
 
 # CoinPaprika Kotlin SDK

--- a/get-started/sdk-php.mdx
+++ b/get-started/sdk-php.mdx
@@ -1,6 +1,7 @@
 ---
 title: "PHP SDK"
 description: "Official CoinPaprika API PHP client library"
+keywords: ["crypto api php", "coinpaprika php sdk", "php crypto data"]
 ---
 
 # CoinPaprika PHP SDK

--- a/get-started/sdk-python.mdx
+++ b/get-started/sdk-python.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Python SDK"
 description: "Official CoinPaprika API Python client library"
+keywords: ["crypto api python", "cryptocurrency api python", "coinpaprika python sdk", "python crypto data", "crypto price api python"]
 ---
 
 # CoinPaprika Python SDK

--- a/get-started/sdk-rust.mdx
+++ b/get-started/sdk-rust.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Rust SDK"
 description: "Official CoinPaprika API Rust client library"
+keywords: ["crypto api rust", "coinpaprika rust sdk", "rust crypto data"]
 ---
 
 # CoinPaprika Rust SDK

--- a/get-started/sdk-swift.mdx
+++ b/get-started/sdk-swift.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Swift SDK"
 description: "Official CoinPaprika API Swift client library"
+keywords: ["crypto api swift", "coinpaprika swift sdk", "swift crypto data", "ios crypto api"]
 ---
 
 # CoinPaprika Swift SDK

--- a/index.mdx
+++ b/index.mdx
@@ -2,6 +2,7 @@
 title: CoinPaprika Crypto API — Price & Market Data for Developers 
 sidebarTitle: "Quickstart"
 description: "Real-time cryptocurrency market data API: prices, volume, market cap, and historical data via REST & WebSocket. Build with CoinPaprika's reliable crypto API."
+keywords: ["crypto api", "crypto api free", "free crypto api", "crypto price api", "cryptocurrency api", "affordable cryptocurrency api", "crypto market data api"]
 ---
 
 <CardGroup cols={2}>

--- a/mcp-connect-claude-cursor.mdx
+++ b/mcp-connect-claude-cursor.mdx
@@ -2,6 +2,7 @@
 title: 'Connect Claude Desktop or Cursor'
 sidebarTitle: "Claude & Cursor Integration"
 description: 'Step-by-step guide to connect your AI development environment to the CoinPaprika MCP Server for real-time cryptocurrency data access'
+keywords: ["crypto mcp", "coinpaprika mcp", "connect claude crypto", "cursor crypto mcp", "crypto data claude"]
 ---
 
 ## What you'll learn

--- a/mcp-introduction.mdx
+++ b/mcp-introduction.mdx
@@ -2,6 +2,7 @@
 title: 'CoinPaprika Crypto MCP Server'
 sidebarTitle: "Model Context Protocol Server"
 description: 'Access real-time cryptocurrency data in Claude, Cursor, and other MCP-compatible tools through our hosted MCP server'
+keywords: ["crypto mcp", "coinpaprika mcp", "crypto market data for llms", "mcp server crypto", "live crypto prices ai agent", "claude crypto", "chatgpt crypto data"]
 ---
 
 ## What is MCP?

--- a/mcp-json-rpc-usage.mdx
+++ b/mcp-json-rpc-usage.mdx
@@ -2,6 +2,7 @@
 title: 'JSON-RPC Usage Guide'
 sidebarTitle: "JSON-RPC Integration"
 description: 'Quick guide to make direct API calls to the CoinPaprika MCP Server using JSON-RPC'
+keywords: ["crypto mcp", "coinpaprika mcp", "mcp json rpc", "crypto mcp api"]
 ---
 
 ## Quick Start

--- a/skills.mdx
+++ b/skills.mdx
@@ -2,6 +2,7 @@
 title: "Install CoinPaprika agent skills"
 sidebarTitle: "Agent Skills"
 description: "Add the CoinPaprika skill to Claude Code, Cursor, or any compatible AI agent with one command. Gives your agent full knowledge of the CoinPaprika REST API, CLI, and SDKs."
+keywords: ["coinpaprika skills", "crypto agent skills", "claude code crypto skills", "crypto ai agent"]
 ---
 
 ## What are agent skills?

--- a/tools/coverage.mdx
+++ b/tools/coverage.mdx
@@ -2,6 +2,7 @@
 title: "Coverage checker - Check if an asset exists in CoinPaprika's dataset"
 sidebarTitle: "Coverage Checker"
 description: "Use this tool to quickly verify whether an asset exists in CoinPaprika's dataset. Enter a contract address, token name, or ticker symbol; we’ll search our coverage and show the closest matches."
+keywords: ["crypto coverage", "supported cryptocurrencies", "crypto exchanges list", "coinpaprika coverage"]
 ---
 
 import { useState } from "react"


### PR DESCRIPTION
## What this does

Adds targeted `keywords` frontmatter to 22 high-value pages to strengthen search visibility and to improve the in-docs Mintlify search ranking (which uses `keywords`).

Additive only. Titles and descriptions are unchanged (already strong).

## Themes and pages

- **Free crypto API funnel** (`crypto api free`, `free crypto api`, `affordable cryptocurrency api`): index, api-plans, get-started/api-rest-introduction.
- **REST reference** (`crypto historical price api`, `coinmarketcap api alternative`, `market cap api`, `crypto volume api`): api-reference/rest-api/introduction.
- **Streaming** (`sse crypto api`, `real-time crypto prices`, `websocket crypto price`): the two streaming-api pages.
- **Crypto MCP / AI** (`crypto mcp`, `coinpaprika mcp`, `live crypto prices ai agent`, `crypto market data for llms`): mcp-introduction, mcp-connect-claude-cursor, mcp-json-rpc-usage.
- **SDKs** (`crypto api python/javascript/go/php/rust/kotlin/swift`): all seven get-started SDK pages.
- **Agents / tools** (`coinpaprika skills`, `coinpaprika cli`, crypto coverage): skills, claude-code-plugin, cli, tools/coverage, faq, dexpaprika.

## Scope and limits

This is the structured-data SEO that Mintlify supports natively (per-page meta via frontmatter). Richer schema (TechArticle JSON-LD, correcting the auto-generated `creator` from Mintlify) is not configurable on Mintlify and is tracked separately.

## Verification

- All 22 frontmatter blocks parse as valid YAML with a `keywords` list.
- Diff is purely additive (one keywords line per page).
- No em dashes introduced.
