### PR TITLE
Pin mcp-remote@latest in the Claude Desktop connect guide

### DIFF
--- a/mcp-connect-claude-cursor.mdx
+++ b/mcp-connect-claude-cursor.mdx
@@ -42,7 +42,7 @@ If the file doesn't exist, create it with this content:
   "mcpServers": {
     "coinpaprika": {
       "command": "npx",
-      "args": ["mcp-remote", "https://mcp.coinpaprika.com/sse"]
+      "args": ["mcp-remote@latest", "https://mcp.coinpaprika.com/sse"]
     }
   }
 }
@@ -52,7 +52,7 @@ If the file already exists, add our server to the existing `mcpServers` object:
 ```json
 "coinpaprika": {
   "command": "npx",
-  "args": ["mcp-remote", "https://mcp.coinpaprika.com/sse"]
+  "args": ["mcp-remote@latest", "https://mcp.coinpaprika.com/sse"]
 }
 ```
 


### PR DESCRIPTION
Both config blocks on mcp-connect-claude-cursor used a bare `mcp-remote` spec. npx can keep reusing whatever version landed in its cache on first run, and I found a machine here with mcp-remote@0.1.9 cached while 0.1.38 is current. With `@latest` the tag gets re-resolved, so readers who set this up months ago won't be stuck bridging through an old proxy.

Two-line change, both JSON blocks verified to still parse.

Tracked in coinpaprika/devrel#105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173YNpx5QzT3wsVDCxjtKZF