### PR TITLE
Update DexPaprika coverage numbers on the Claude Code plugin page

### DIFF
--- a/claude-code-plugin.mdx
+++ b/claude-code-plugin.mdx
@@ -183,7 +183,7 @@ The same marketplace also hosts the **DexPaprika plugin** for on-chain DEX data.
 ```
 
 - **CoinPaprika** -- CEX data: 12,000+ coins, 350+ exchanges, market caps, OHLCV
-- **DexPaprika** -- DEX data: 34 blockchains, 30M+ pools, on-chain token prices, streaming
+- **DexPaprika** -- DEX data: 36 blockchains, 36M+ pools, on-chain token prices, streaming
 
 ---
 


### PR DESCRIPTION
The DexPaprika bullet on the Claude Code plugin page still said 34 blockchains and 30M+ pools. Current live stats from the API say otherwise, so I bumped the numbers.

Verified today against https://api.dexpaprika.com/stats:

```
{"chains":36,"factories":231,"pools":36306148,"tokens":33574382}
```

Changed 34 blockchains to 36 and 30M+ pools to 36M+. CoinPaprika numbers on the same page (12,000+ coins, 350+ exchanges) are still accurate and left as they are.

I grepped the rest of the repo for stale DexPaprika coverage claims (chains, tokens, pools, DEX counts) and this was the only spot.