### PR TITLE
Fix 4 broken links + Rust SDK 'official' mislabel

### DIFF
--- a/api-plans.mdx
+++ b/api-plans.mdx
@@ -33,7 +33,7 @@ For the most up-to-date pricing and to subscribe, please visit our official [**P
 | Feature | Free | Starter | Pro | Business<br/>(Bestseller) | Ultimate | Enterprise |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Price per month** | $0/mo | $99.00/mo | $199.00/mo | $799.00/mo | $1,499.00/mo | Custom |
-| **<a href="/api-reference/introduction">Endpoints</a>** | 25+ | 25+ | 25+ | 25+ | 25+ | 25+ |
+| **<a href="/api-reference/rest-api/introduction">Endpoints</a>** | 25+ | 25+ | 25+ | 25+ | 25+ | 25+ |
 | **Calls / month** | 20,000 | 400,000 | 1,000,000 | 5,000,000 | 10,000,000 | No limits |
 | **Assets available** | 2,000 | All | All | All | All | All |
 </div>

--- a/dexpaprika.mdx
+++ b/dexpaprika.mdx
@@ -77,7 +77,7 @@ If your project involves DeFi, on-chain analysis, or tracking assets on decentra
     title="Back to CoinPaprika API"
     icon="arrow-left"
     color="#CE0017"
-    href="/api-reference/introduction"
+    href="/api-reference/rest-api/introduction"
   >
     Continue exploring the features of the CoinPaprika API.
   </Card>

--- a/faq.mdx
+++ b/faq.mdx
@@ -29,7 +29,7 @@ keywords: ["crypto api faq", "coinpaprika api", "crypto api help"]
     For more, please visit our full [REST API Reference](/api-reference/rest-api/introduction).
   </Accordion>
   <Accordion title="Are there API clients or SDKs?">
-    Yes, we have SDKs for popular programming languages such as Python, PHP, Go, and JS/TS. You can see the full list in our [Getting Started guide](/api-reference/introduction#sdks).
+    Yes, we have SDKs for popular programming languages such as Python, PHP, Go, and JS/TS. You can see the full list in our [Getting Started guide](/api-reference/rest-api/introduction#sdks).
 
     Before using an SDK provided by the community, please check its version and compatibility. If your programming language is not supported, don't worry; the API is provided in a standard JSON/REST format, and its implementation is usually straightforward.
   </Accordion>
@@ -45,7 +45,7 @@ keywords: ["crypto api faq", "coinpaprika api", "crypto api help"]
     Yes, the WebSocket protocol is included in the Enterprise plan. Please contact us for details.
   </Accordion>
   <Accordion title="Are there any rate limits?">
-    We have a global limit of 10 requests/second per IP. Other limits on the number of queries are assigned to the corresponding plan and detailed in the documentation. When the limits are reached, the API returns HTTP codes `429` or `402`. You can find the monthly limits for each plan in our [Getting Started guide](/api-reference/introduction#rate-limits).
+    We have a global limit of 10 requests/second per IP. Other limits on the number of queries are assigned to the corresponding plan and detailed in the documentation. When the limits are reached, the API returns HTTP codes `429` or `402`. You can find the monthly limits for each plan in our [Getting Started guide](/api-reference/rest-api/introduction#rate-limits).
   </Accordion>
   <Accordion title="Where can I check my limits?">
     Limits on the number of HTTP requests are defined according to the selected plan. They can be checked using the [/key/info](/api-reference/key/get-api-key-info) endpoint. Customers using the Enterprise package do not have a limit on the number of requests.

--- a/get-started/sdk-go.mdx
+++ b/get-started/sdk-go.mdx
@@ -390,7 +390,7 @@ The Go SDK is organized into services that correspond to the API endpoints.
 - [`client.Coins.GetEventsByCoinID(coinID)`](/api-reference/coins/get-coin-events-by-coin-id) - Get events for a coin.
 - [`client.Coins.GetExchangesByCoinID(coinID)`](/api-reference/coins/get-exchanges-by-coin-id) - Get exchanges for a coin.
 - [`client.Coins.GetMarketsByCoinID(coinID)`](/api-reference/coins/get-markets-by-coin-id) - Get markets for a coin.
-- [`client.Coins.GetTwitterByCoinID(coinID)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin) - Get Twitter timeline for a coin.
+- [`client.Coins.GetTwitterByCoinID(coinID)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin-deprecated) - Get Twitter timeline for a coin.
 - [`client.Coins.GetOHLCVLastFullDayByCoinID(coinID)`](/api-reference/coins/get-ohlc-for-the-last-full-day) - Get OHLCV for the last full day.
 - [`client.Coins.GetOHLCVHistorical(coinID, options)`](/api-reference/coins/get-historical-ohlc) - Get historical OHLCV.
 - [`client.Coins.GetOHLCVTodayByCoinID(coinID)`](/api-reference/coins/get-today-ohlc) - Get today's OHLCV.
@@ -435,7 +435,7 @@ The Go SDK is organized into services that correspond to the API endpoints.
 
 ## Examples Repository
 
-Check out practical examples in the [official repository](https://github.com/coinpaprika/coinpaprika-api-go-client/tree/main/examples).
+Check out practical examples in the [official repository](https://github.com/coinpaprika/coinpaprika-api-go-client/tree/master/examples).
 
 ## Requirements
 

--- a/get-started/sdk-kotlin.mdx
+++ b/get-started/sdk-kotlin.mdx
@@ -151,7 +151,7 @@ Used to fetch coin details and history.
 - [`getCoinEvents(id)`](/api-reference/coins/get-coin-events-by-coin-id): Gets events related to a coin.
 - [`getCoinExchanges(id)`](/api-reference/coins/get-exchanges-by-coin-id): Gets exchanges where a coin is listed.
 - [`getCoinMarkets(id, quotes)`](/api-reference/coins/get-markets-by-coin-id): Gets market data for a coin.
-- [`getCoinTweets(id)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin): Gets the latest tweets for a coin.
+- [`getCoinTweets(id)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin-deprecated): Gets the latest tweets for a coin.
 - [`getCoinOHLCV(id, quotes)`](/api-reference/coins/get-ohlc-for-the-last-full-day): Gets the latest OHLCV data.
 - [`getHistoricalCoinOHLCV(...)`](/api-reference/coins/get-historical-ohlc): Gets historical OHLCV data.
 

--- a/get-started/sdk-php.mdx
+++ b/get-started/sdk-php.mdx
@@ -243,7 +243,7 @@ try {
 
 ## Examples Repository
 
-For more detailed examples, please see the [official repository](https://github.com/coinpaprika/coinpaprika-api-php-client/tree/main/examples).
+For more detailed examples, please see the [official repository](https://github.com/coinpaprika/coinpaprika-api-php-client/tree/master/examples).
 
 ## License
 

--- a/get-started/sdk-python.mdx
+++ b/get-started/sdk-python.mdx
@@ -248,7 +248,7 @@ except CoinpaprikaAPIException as e:
 ### Coins
 - [`coins()`](/api-reference/coins/list-coins) - List all coins.
 - [`coin(coin_id)`](/api-reference/coins/get-coin-by-id) - Get details for a specific coin.
-- [`twitter(coin_id)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin) - Get a coin's Twitter timeline.
+- [`twitter(coin_id)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin-deprecated) - Get a coin's Twitter timeline.
 - [`events(coin_id)`](/api-reference/coins/get-coin-events-by-coin-id) - Get a coin's events.
 - [`exchanges(coin_id)`](/api-reference/coins/get-exchanges-by-coin-id) - Get exchanges for a specific coin.
 - [`markets(coin_id, **params)`](/api-reference/coins/get-markets-by-coin-id) - Get market data for a specific coin.

--- a/get-started/sdk-rust.mdx
+++ b/get-started/sdk-rust.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Rust SDK"
-description: "Official CoinPaprika API Rust client library"
+description: "Community-maintained CoinPaprika API Rust client library"
 keywords: ["crypto api rust", "coinpaprika rust sdk", "rust crypto data"]
 ---
 
 # CoinPaprika Rust SDK
 
-The official Rust client library for the CoinPaprika API provides convenient access to cryptocurrency market data.
+A community-maintained Rust client library for the CoinPaprika API provides convenient access to cryptocurrency market data.
 
 <Note>
-This SDK was built by the courtesy of [Tokenomia Pro](https://tokenomia.pro).
+This is a community client built by [Tokenomia Pro](https://tokenomia.pro), not maintained by CoinPaprika. The [`coinpaprika_api`](https://docs.rs/coinpaprika-api) crate is published independently, so CoinPaprika support does not cover it. For officially maintained clients, see the Python, PHP, or Go SDKs.
 </Note>
 
 ## Installation
@@ -130,7 +130,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 ### Coins
 - [List coins](/api-reference/coins/list-coins)
 - [Get coin by ID](/api-reference/coins/get-coin-by-id)
-- [Get Twitter timeline tweets for a coin](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin)
+- [Get Twitter timeline tweets for a coin](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin-deprecated)
 - [Get coin events by coin ID](/api-reference/coins/get-coin-events-by-coin-id)
 - [Get exchanges by coin ID](/api-reference/coins/get-exchanges-by-coin-id)
 - [Get markets by coin ID](/api-reference/coins/get-markets-by-coin-id)

--- a/get-started/sdk-swift.mdx
+++ b/get-started/sdk-swift.mdx
@@ -249,7 +249,7 @@ func getMarketData() async {
 ### Coins
 - [`coins(additionalFields:)`](/api-reference/coins/list-coins) - List all coins.
 - [`coin(id:)`](/api-reference/coins/get-coin-by-id) - Get coin by ID.
-- [`coinTwitter(id:)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin) - Get a coin's Twitter timeline.
+- [`coinTwitter(id:)`](/api-reference/coins/get-twitter-timeline-tweets-for-a-coin-deprecated) - Get a coin's Twitter timeline.
 - [`coinEvents(id:)`](/api-reference/coins/get-coin-events-by-coin-id) - Get coin events.
 - [`coinExchanges(id:)`](/api-reference/coins/get-exchanges-by-coin-id) - Get exchanges for a coin.
 - [`coinMarkets(id:quotes:)`](/api-reference/coins/get-markets-by-coin-id) - Get markets for a coin.


### PR DESCRIPTION
A full link crawl of docs.coinpaprika.com found 4 broken links. Fixing them surfaced a fifth issue on the Rust SDK page. Every claim below was re-verified live today, and each replacement target returns 200.

## Broken links

| Broken | Fix | Files |
| --- | --- | --- |
| `/api-reference/introduction` (404) | `/api-reference/rest-api/introduction` | `dexpaprika.mdx`, `api-plans.mdx`, `faq.mdx` (x2, with `#sdks` / `#rate-limits` anchors, both of which exist on the new page) |
| `/api-reference/coins/get-twitter-timeline-tweets-for-a-coin` (404) | same slug with `-deprecated` suffix | 5 SDK pages (python, rust, swift, kotlin, go) |
| `coinpaprika-api-go-client/tree/main/examples` (404) | `tree/master/examples` | `sdk-go.mdx` |
| `coinpaprika-api-php-client/tree/main/examples` (404) | `tree/master/examples` | `sdk-php.mdx` |

Notes on the diagnoses, since two differed from the original report:

- **The Twitter endpoint is not gone.** `api.coinpaprika.com/v1/coins/btc-bitcoin/twitter` still returns 200. The reference page was renamed with a `-deprecated` suffix, so the fix is to repoint the links, not remove them.
- **The examples dirs were never missing.** Both repos default to `master`, not `main`, and `examples/` is present there. The links just used the wrong branch name.
- The DexPaprika cross-link on `dexpaprika.mdx:72` (`docs.dexpaprika.com/api-reference/introduction`) resolves and is left untouched.

## Rust SDK mislabel

While fixing the Rust page's Twitter link, I noticed it calls the crate the **official** CoinPaprika Rust SDK in two places (frontmatter and intro). It is not ours. `coinpaprika_api` is published by Tokenomia Pro, last released in 2022, and lives outside the CoinPaprika org. The Go, Python and PHP SDK pages use the same "official" template wording and *are* correct, because those are org repos; Rust is the odd one out.

Reworded to "community-maintained" and expanded the existing Tokenomia Pro note so readers know it is independent and not covered by CoinPaprika support, with a pointer to the genuinely official SDKs. Linked to `docs.rs/coinpaprika-api` rather than crates.io, because the crates.io page is a client-rendered SPA that returns 404 to crawlers and would re-trip a link checker.

This is the docs side of coinpaprika/devrel#129, which tracks the broader build-vs-adopt decision for a Rust SDK.

Refs coinpaprika/devrel#133, coinpaprika/devrel#129