### PR TITLE
SEO: unique per-page titles, single H1, fix php LICENSE link

### DIFF
--- a/api-reference/streaming-api/streaming-api-tutorial.mdx
+++ b/api-reference/streaming-api/streaming-api-tutorial.mdx
@@ -4,8 +4,6 @@ description: "A step-by-step guide to connecting to the CoinPaprika Streaming AP
 keywords: ["crypto streaming api tutorial", "real-time crypto prices", "sse crypto api", "live crypto price stream"]
 ---
 
-# Your First Crypto Stream in 5 Minutes
-
 Want to start streaming real-time crypto data right now? This guide will get you connected to the CoinPaprika Streaming API and receiving live price updates in **less than 5 minutes**.
 
 We'll walk you through a simple copy-paste Node.js script. No complex setup, just instant data.

--- a/api-reference/streaming-api/streaming-introduction.mdx
+++ b/api-reference/streaming-api/streaming-introduction.mdx
@@ -4,8 +4,6 @@ description: "High-frequency cryptocurrency data via WebSocket"
 keywords: ["crypto streaming api", "real-time crypto prices", "sse crypto api", "live crypto price stream", "websocket crypto price"]
 ---
 
-# CoinPaprika Streaming API
-
 The CoinPaprika Streaming API provides high-frequency cryptocurrency ticker data via WebSocket connections, allowing you to get live price updates, market cap changes, and volume data for your favorite cryptocurrencies.
 
 ## Getting Started

--- a/docs.json
+++ b/docs.json
@@ -233,13 +233,11 @@
   "seo": {
     "indexing": "all",
     "metatags": {
-      "title": "Crypto API - Price & Market Data API | CoinPaprika",
       "description": "Official documentation for the CoinPaprika API. Access latest and historical cryptocurrency market data, including prices, volumes, market caps, and more.",
       "keywords": "CoinPaprika, CoinPaprika API, crypto API, cryptocurrency API, blockchain data, real-time crypto prices, historical crypto data, token data, developer API, REST API, WebSocket API",
       "author": "CoinPaprika",
       "robots": "index, follow",
       "googlebot": "index, follow",
-      "og:title": "Crypto API - Price & Market Data API | CoinPaprika",
       "og:description": "The official developer documentation for the CoinPaprika API. Find guides, API references, and tutorials to integrate comprehensive crypto data.",
       "og:type": "website",
       "og:url": "https://docs.coinpaprika.com",
@@ -248,7 +246,6 @@
       "twitter:card": "summary_large_image",
       "twitter:site": "@coinpaprika",
       "twitter:creator": "@coinpaprika",
-      "twitter:title": "Crypto API - Price & Market Data API | CoinPaprika",
       "twitter:description": "Your complete guide to integrating low-latency and historical cryptocurrency data with the powerful CoinPaprika API.",
       "twitter:image": "https://coinpaprika.com/opengraph-image.png"
     }

--- a/get-started/sdk-go.mdx
+++ b/get-started/sdk-go.mdx
@@ -4,8 +4,6 @@ description: "Official CoinPaprika API Go client library"
 keywords: ["crypto api go", "crypto api golang", "coinpaprika go sdk", "golang crypto data"]
 ---
 
-# CoinPaprika Go SDK
-
 The official Go client library for the CoinPaprika API provides convenient access to cryptocurrency market data, including coin prices, volumes, market caps, and more.
 
 ## Installation

--- a/get-started/sdk-javascript.mdx
+++ b/get-started/sdk-javascript.mdx
@@ -4,8 +4,6 @@ description: "Official CoinPaprika API Node.js client library"
 keywords: ["crypto api javascript", "crypto api node", "coinpaprika javascript sdk", "js crypto data"]
 ---
 
-# CoinPaprika JavaScript SDK
-
 The official Node.js client library for the CoinPaprika API provides convenient access to cryptocurrency market data.
 
 <Tip>

--- a/get-started/sdk-kotlin.mdx
+++ b/get-started/sdk-kotlin.mdx
@@ -4,8 +4,6 @@ description: "Official CoinPaprika API Kotlin/Android client building blocks"
 keywords: ["crypto api kotlin", "coinpaprika kotlin sdk", "kotlin crypto data", "android crypto api"]
 ---
 
-# CoinPaprika Kotlin SDK
-
 The official Kotlin library for the CoinPaprika API provides a set of Retrofit interfaces and data models to access cryptocurrency market data. This allows for easy integration into any Android or Kotlin project that uses Retrofit for networking.
 
 This library provides the building blocks, not a pre-configured client. You are responsible for creating and configuring your own `Retrofit` instance.

--- a/get-started/sdk-php.mdx
+++ b/get-started/sdk-php.mdx
@@ -4,8 +4,6 @@ description: "Official CoinPaprika API PHP client library"
 keywords: ["crypto api php", "coinpaprika php sdk", "php crypto data"]
 ---
 
-# CoinPaprika PHP SDK
-
 The official PHP client library for the CoinPaprika API provides convenient access to cryptocurrency market data. It uses Guzzle for HTTP requests and the JMS/Serializer for handling API responses.
 
 <Tip>
@@ -247,4 +245,4 @@ For more detailed examples, please see the [official repository](https://github.
 
 ## License
 
-This library is available under the MIT license. See the [LICENSE file](https://github.com/coinpaprika/coinpaprika-api-php-client/blob/master/LICENSE.md) for more info. 
+This library is available under the MIT license. See the [LICENSE file](https://github.com/coinpaprika/coinpaprika-api-php-client/blob/master/LICENSE) for more info. 

--- a/get-started/sdk-python.mdx
+++ b/get-started/sdk-python.mdx
@@ -4,8 +4,6 @@ description: "Official CoinPaprika API Python client library"
 keywords: ["crypto api python", "cryptocurrency api python", "coinpaprika python sdk", "python crypto data", "crypto price api python"]
 ---
 
-# CoinPaprika Python SDK
-
 The official Python client library for the CoinPaprika API provides convenient access to cryptocurrency market data.
 
 <Tip>

--- a/get-started/sdk-rust.mdx
+++ b/get-started/sdk-rust.mdx
@@ -4,8 +4,6 @@ description: "Community-maintained CoinPaprika API Rust client library"
 keywords: ["crypto api rust", "coinpaprika rust sdk", "rust crypto data"]
 ---
 
-# CoinPaprika Rust SDK
-
 A community-maintained Rust client library for the CoinPaprika API provides convenient access to cryptocurrency market data.
 
 <Note>

--- a/get-started/sdk-swift.mdx
+++ b/get-started/sdk-swift.mdx
@@ -4,8 +4,6 @@ description: "Official CoinPaprika API Swift client library"
 keywords: ["crypto api swift", "coinpaprika swift sdk", "swift crypto data", "ios crypto api"]
 ---
 
-# CoinPaprika Swift SDK
-
 The official Swift client library for the CoinPaprika API provides convenient, static access to cryptocurrency market data.
 
 ## Installation


### PR DESCRIPTION
Three SEO fixes from a docs.coinpaprika.com review. All verified live / with `mintlify dev`.

## 1. Every page had the same `<title>` (P1)

A global `seo.metatags.title` in `docs.json` stamped `Crypto API - Price & Market Data API | CoinPaprika` on all pages, so Google couldn't tell them apart. We ranked for brand terms but sat mid-page on generic ones. Removed the global `title` (and matching `og:title`/`twitter:title`) so each page uses its own title. `mintlify dev` confirms distinct titles now (`Go SDK - ...`, `Get coin by ID - ...`, etc.).

## 2. Double H1 on 9 pages

Mintlify already renders the frontmatter title as the page H1, but nine pages also opened with a Markdown `# Heading` (a second H1): the 7 SDK pages plus `streaming-introduction` and `streaming-api-tutorial`. Removed the redundant leading heading. Verified one H1 per page.

## 3. Broken php LICENSE link

`get-started/sdk-php` linked to `coinpaprika-api-php-client/blob/master/LICENSE.md` (404). The repo's license file is `LICENSE` (no extension). Repointed to `/blob/master/LICENSE`.

## Follow-up (not here)

Some frontmatter titles carry a long redundant suffix and a couple use em dashes; those can be trimmed in a separate pass. The uniqueness win is delivered here. `docs.json` change is a clean 3-line removal.