### PR TITLE
Fix wrong plan quotas, a broken SDK link and stale counts in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The documentation is built with Mintlify and consists of:
 
 The technical API references are rendered directly from their specification files. Unlike other setups, there is no scraping or code generation step required to update the documentation for the REST or Streaming APIs.
 
-- **To update the REST API:** Modify the content of `documentation/api-reference/rest-api/openapi.yml`.
-- **To update the Streaming API:** Modify the content of `documentation/api-reference/streaming-api/asyncapi.yml`.
+- **To update the REST API:** Modify the content of `api-reference/rest-api/openapi.yml`.
+- **To update the Streaming API:** Modify the content of `api-reference/streaming-api/asyncapi.yml`.
 
 Mintlify will automatically reflect the changes in the documentation when you run the local development server or when the site is deployed.
 
@@ -25,9 +25,8 @@ To preview your changes on your local machine before publishing:
 
 1.  **Clone the repository**:
     ```bash
-    # Replace with the correct repository URL
-    git clone https://github.com/coinpaprika/coinpaprika-api-docs
-    cd coinpaprika-api-docs/documentation
+    git clone https://github.com/r--w/documentation
+    cd documentation
     ```
 2.  **Install Mintlify CLI** (this only needs to be done once):
     ```bash
@@ -54,8 +53,8 @@ To preview your changes on your local machine before publishing:
 
 - **To update API docs:** Simply edit the corresponding `openapi.yml` or `asyncapi.yml` file. No scraping command is needed.
 - **To add guides or pages:** Create a new `.mdx` file and add it to the navigation structure in `docs.json`.
-- **To test changes:** Run `mintlify dev` from within the `documentation` directory.
+- **To test changes:** Run `mintlify dev` from the repository root.
 - **`docs.json` is the master file:** It controls navigation, appearance, and site-wide settings.
 - For more information on Mintlify features and components, visit the official [Mintlify Documentation](https://mintlify.com/docs/getting-started).
 
-If you have any questions, please reach out to the team. 🚀  
+If you have any questions, please reach out to the team.

--- a/api-plans.mdx
+++ b/api-plans.mdx
@@ -18,6 +18,7 @@ Depending on the selected plan, you should send requests to the appropriate base
 | **Starter** | `https://api-pro.coinpaprika.com/v1/` |
 | **Pro** | `https://api-pro.coinpaprika.com/v1/` |
 | **Business** | `https://api-pro.coinpaprika.com/v1/` |
+| **Ultimate** | `https://api-pro.coinpaprika.com/v1/` |
 | **Enterprise** | `https://api-pro.coinpaprika.com/v1/` |
 </div>
 
@@ -226,7 +227,7 @@ For the most up-to-date pricing and to subscribe, please visit our official [**P
             <td>❌</td>
             <td>❌</td>
             <td>❌</td>
-            <td>✅<br/><sub>(contact Sales Dept.)</sub></td>
+            <td>❌</td>
             <td>✅<br/><sub>(contact Sales Dept.)</sub></td>
             <td>✅<br/><sub>(contact Sales Dept.)</sub></td>
         </tr>

--- a/api-reference/rest-api/introduction.mdx
+++ b/api-reference/rest-api/introduction.mdx
@@ -122,8 +122,26 @@ We offer several SDKs to help you integrate with our API more easily:
     title="TypeScript"
     icon="code-branch"
     color="#CE0017"
-    href="https://github.com/coinpaprika/coinpaprika-api-js-client"
+    href="https://github.com/coinpaprika/coinpaprika-api-nodejs-client"
   >
     Official TypeScript/JavaScript client for the CoinPaprika API.
+  </Card>
+</CardGroup>
+<CardGroup cols={2}>
+  <Card
+    title="Swift"
+    icon="code-branch"
+    color="#CE0017"
+    href="https://github.com/coinpaprika/coinpaprika-api-swift-client"
+  >
+    Official Swift client for iOS and macOS.
+  </Card>
+  <Card
+    title="Kotlin"
+    icon="code-branch"
+    color="#CE0017"
+    href="https://github.com/coinpaprika/coinpaprika-api-kotlin-client"
+  >
+    Official Kotlin/Android client for the CoinPaprika API.
   </Card>
 </CardGroup>

--- a/api-reference/rest-api/openapi.yml
+++ b/api-reference/rest-api/openapi.yml
@@ -24,6 +24,7 @@ info:
     | Starter    | https://api-pro.coinpaprika.com/v1/ |
     | Pro        | https://api-pro.coinpaprika.com/v1/ |
     | Business   | https://api-pro.coinpaprika.com/v1/ |
+    | Ultimate   | https://api-pro.coinpaprika.com/v1/ |
     | Enterprise | https://api-pro.coinpaprika.com/v1/ |
 
     # Authentication
@@ -62,9 +63,10 @@ info:
       | Plan       | Calls/month                         |
       |------------|-------------------------------------|
       | Free       | 20 000 |
-      | Starter    | 200 000 |
-      | Pro        | 500 000 |
-      | Business   | 3 000 000 |
+      | Starter    | 400 000 |
+      | Pro        | 1 000 000 |
+      | Business   | 5 000 000 |
+      | Ultimate   | 10 000 000 |
       | Enterprise | No limits |
 
     # API Clients

--- a/api-reference/streaming-api/streaming-api-tutorial.mdx
+++ b/api-reference/streaming-api/streaming-api-tutorial.mdx
@@ -10,7 +10,7 @@ We'll walk you through a simple copy-paste Node.js script. No complex setup, jus
 
 ## What You'll Need
 
-*   **A CoinPaprika API Key**: If you don't have one, get it from the [CoinPaprika API page](https://coinpaprika.com/api/panel/).
+*   **A CoinPaprika API Key on the Enterprise plan**: WebSocket streaming is part of the Enterprise plan, so a Free, Starter, Pro, Business or Ultimate key will not open a connection. See [API Plans](/api-plans) for the comparison, or [contact us](https://coinpaprika.com/contact/) to talk about Enterprise. Existing Enterprise customers can get the key from the [CoinPaprika API panel](https://coinpaprika.com/api/panel/).
 *   **Node.js**: If you don't have it installed, download it from the [official Node.js website](https://nodejs.org/).
 
 ## Step 1: Set Up Your Project (1 Minute)

--- a/api-reference/streaming-api/streaming-introduction.mdx
+++ b/api-reference/streaming-api/streaming-introduction.mdx
@@ -22,6 +22,12 @@ All requests require authentication using your API key. You must include it in t
 
 To get your API key, visit the [CoinPaprika API](https://coinpaprika.com/api/) page.
 
+<Note>
+  WebSocket streaming is part of the Enterprise plan. Keys issued on the Free, Starter, Pro,
+  Business and Ultimate plans do not open a streaming connection. See [API Plans](/api-plans)
+  for the full comparison, or [contact us](https://coinpaprika.com/contact/) about Enterprise.
+</Note>
+
 ### 3. Finding IDs
 *   **Currency IDs (`ids`)**: To subscribe to a currency, you need its unique ID (e.g., `"btc-bitcoin"`). You can find these IDs by using the [Coins endpoint](https://docs.coinpaprika.com/api-reference/coins/get-coin-by-id) from our REST API.
 *   **Quote Currencies (`quotes`)**: You can receive prices quoted in various currencies. The currently supported quote currencies are: `USD`, `BTC`, `ETH`, `BNB`, `MATIC`, `SOL`.

--- a/claude-code-plugin.mdx
+++ b/claude-code-plugin.mdx
@@ -62,7 +62,7 @@ The CoinPaprika plugin includes:
 
 | Component | What it does |
 |---|---|
-| **29 MCP tools** | Live data access: tickers, coins, exchanges, OHLCV, contracts, tags, search, conversion |
+| **31 MCP tools** | Live data access: tickers, coins, exchanges, OHLCV, contracts, tags, search, conversion |
 | **@crypto-analyst agent** | Specialized agent for market analysis and portfolio queries |
 | **Agent skills** | API reference files that give Claude deeper knowledge of CoinPaprika endpoints |
 
@@ -163,7 +163,7 @@ Select "Manage Plugins" to see all installed plugins and their status.
 | | Claude Code Plugin | Hosted MCP Server | Agent Skills |
 |---|---|---|---|
 | **Install** | `/plugin install` | Add URL to config | `npx skills add` |
-| **What you get** | MCP tools + agent + skills (all bundled) | 29 MCP tools | API knowledge (endpoints, CLI, workflows) |
+| **What you get** | MCP tools + agent + skills (all bundled) | 31 MCP tools | API knowledge (endpoints, CLI, workflows) |
 | **Works with** | Claude Code only | Claude Desktop, Cursor, VS Code | Claude Code, Cursor, Cline, and more |
 | **Best for** | Claude Code users who want everything in one install | Other AI IDEs | Any agent that makes HTTP calls directly |
 

--- a/cli.mdx
+++ b/cli.mdx
@@ -245,7 +245,9 @@ Check the coin ID format. Use `coinpaprika-cli search <name>` to find the correc
 </Accordion>
 
 <Accordion title="OHLCV or historical data returns an error">
-Historical endpoints (OHLCV, ticker history, contract history) require a Starter plan ($99/mo) or above. Run `coinpaprika-cli plans` to see what's available on the free tier.
+Ticker history and contract history work without a key. `/v1/tickers/{coin_id}/historical` returns a rolling year of daily ticks on the free tier, and `/v1/contracts/{platform}/{address}/historical` redirects to the same data. Ask for an earlier `start` and you get HTTP 402 naming the cutoff.
+
+OHLCV is the one that is gated. `/v1/coins/{coin_id}/ohlcv/latest` works without a key, but `/v1/coins/{coin_id}/ohlcv/historical` returns HTTP 402 for anything before the last full day, so a real OHLCV backfill needs a Starter plan ($99/mo) or above. Run `coinpaprika-cli plans` to see what's available on the free tier.
 </Accordion>
 </AccordionGroup>
 

--- a/faq.mdx
+++ b/faq.mdx
@@ -13,7 +13,7 @@ keywords: ["crypto api faq", "coinpaprika api", "crypto api help"]
 
 <AccordionGroup>
   <Accordion title="How many assets and exchanges are in your API?">
-    - We have more than 53k assets in our database, of which about 8-10k are active (i.e., where trading has taken place in the last 24 hours). The number of assets is growing all the time, while the number of active assets depends on the market situation.
+    - We have more than 60,000 assets in our database, of which over 11,000 are active (i.e., where trading has taken place in the last 24 hours). The number of assets is growing all the time, while the number of active assets depends on the market situation.
     - We have over 350 active exchanges, covering all of the mainstream CEX platforms, DEXes, and smaller exchanges as well.
   </Accordion>
   <Accordion title="What kind of data can I retrieve from the API?">
@@ -29,7 +29,7 @@ keywords: ["crypto api faq", "coinpaprika api", "crypto api help"]
     For more, please visit our full [REST API Reference](/api-reference/rest-api/introduction).
   </Accordion>
   <Accordion title="Are there API clients or SDKs?">
-    Yes, we have SDKs for popular programming languages such as Python, PHP, Go, and JS/TS. You can see the full list in our [Getting Started guide](/api-reference/rest-api/introduction#sdks).
+    Yes, we have SDKs for popular programming languages such as Python, PHP, Go, JS/TS, Swift, and Kotlin. You can see the full list in our [Getting Started guide](/api-reference/rest-api/introduction#sdks).
 
     Before using an SDK provided by the community, please check its version and compatibility. If your programming language is not supported, don't worry; the API is provided in a standard JSON/REST format, and its implementation is usually straightforward.
   </Accordion>

--- a/get-started/api-rest-introduction.mdx
+++ b/get-started/api-rest-introduction.mdx
@@ -112,7 +112,7 @@ curl -H "Authorization: YOUR_API_KEY" "https://api-pro.coinpaprika.com/v1/key/in
 A successful response returns JSON with your plan, status, and remaining monthly quota.
 
 <Tip>
-**Pro tip:** Start with our free tier - no credit card required. You can make up to 1,000 requests per day without authentication.
+**Pro tip:** Start with our free tier - no credit card required. It gives you 20,000 calls per month across 2,000 assets without authentication.
 </Tip>
 
 You can get your API key by checking out our [pricing page](https://coinpaprika.com/api/pricing/).

--- a/get-started/sdk-kotlin.mdx
+++ b/get-started/sdk-kotlin.mdx
@@ -110,7 +110,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object ProRetrofitClient {
-    // CoinPaprika expects the bare API key — no `Bearer ` prefix.
+    // CoinPaprika expects the bare API key, with no `Bearer ` prefix.
     private val authInterceptor = Interceptor { chain ->
         val key = System.getenv("COINPAPRIKA_API_KEY")
             ?: error("COINPAPRIKA_API_KEY is not set")
@@ -136,7 +136,7 @@ object ProRetrofitClient {
 }
 ```
 
-Free-tier callers don't need any of this — keep the `RetrofitClient` from Quick Start pointed at `COINPAPRIKA_BASE_URL` without an interceptor.
+Free-tier callers don't need any of this. Keep the `RetrofitClient` from Quick Start pointed at `COINPAPRIKA_BASE_URL` without an interceptor.
 
 ## Available Services
 

--- a/get-started/sdk-rust.mdx
+++ b/get-started/sdk-rust.mdx
@@ -174,7 +174,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Use the [Coverage Checker](/tools/coverage) to resolve canonical IDs such as <code>btc-bitcoin</code>.
   </Accordion>
   <Accordion title="Can I get historical data in Rust?">
-    Yes—use the REST historical endpoints via the client methods that accept <code>start</code>/<code>end</code> parameters; an API key is required.
+    Yes. Use the REST historical endpoints via the client methods that accept <code>start</code>/<code>end</code> parameters. The free tier reaches back one year of daily ticks; an API key is required for anything deeper and for OHLCV history beyond the last full day.
   </Accordion>
   <Accordion title="What’s the error handling approach?">
     Propagate <code>Result</code> and map HTTP errors (e.g., 429) to retry/backoff logic in your async runtime.

--- a/get-started/sdk-swift.mdx
+++ b/get-started/sdk-swift.mdx
@@ -49,7 +49,7 @@ Coinpaprika.API.global().perform { result in
 
 ## Authenticating with a paid plan
 
-Paid plans (Starter / Pro / Business / Ultimate / Enterprise) live on a separate hostname, `https://api-pro.coinpaprika.com/v1/`, and require an API key in the `Authorization` header. Send the bare key — a `Bearer ` prefix is rejected by the WAF.
+Paid plans (Starter / Pro / Business / Ultimate / Enterprise) live on a separate hostname, `https://api-pro.coinpaprika.com/v1/`, and require an API key in the `Authorization` header. Send the bare key, because a `Bearer ` prefix is rejected by the WAF.
 
 The high-level `Coinpaprika.API` static methods don't currently accept a key. To call paid endpoints, drop down to the `CoinpaprikaNetworking` `Request<Model>` constructor with `.bearer(token:)` and point it at the Pro base URL. The package exposes `CoinpaprikaNetworking` as a separate library product, so add it to your target's dependencies alongside `Coinpaprika`.
 

--- a/index.mdx
+++ b/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: CoinPaprika Crypto API — Price & Market Data for Developers 
+title: "CoinPaprika Crypto API: price and market data for developers"
 sidebarTitle: "Quickstart"
 description: "Real-time cryptocurrency market data API: prices, volume, market cap, and historical data via REST & WebSocket. Build with CoinPaprika's reliable crypto API."
 keywords: ["crypto api", "crypto api free", "free crypto api", "crypto price api", "cryptocurrency api", "affordable cryptocurrency api", "crypto market data api"]
@@ -24,13 +24,13 @@ keywords: ["crypto api", "crypto api free", "free crypto api", "crypto price api
   </Card>
 </CardGroup>
 
-## CoinPaprika crypto API quickstart — 3 steps, free, no credit card required
+## CoinPaprika crypto API quickstart: 3 steps, free, no credit card required
 
 <div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%', marginBottom: '1rem' }}>
   <iframe 
     style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
     src="https://www.youtube.com/embed/qtt-jJGZz2o?si=Ia5Ajlar4FLLy_Wx"
-    title="Get latest Bitcoin price in under 2 minutes — free API, no signup | CoinPaprika"
+    title="Get latest Bitcoin price in under 2 minutes, free API, no signup | CoinPaprika"
     frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     referrerpolicy="strict-origin-when-cross-origin"

--- a/mcp-json-rpc-usage.mdx
+++ b/mcp-json-rpc-usage.mdx
@@ -118,6 +118,23 @@ All tools follow this structure:
 | getTickerByContract | Ticker by contract address | **platformId**: string; **contractAddress**: string | `{"platformId": "eth-ethereum", "contractAddress": "0x..."}` |
 | priceConverter | Convert base to quote | **baseCurrencyId**: string; **quoteCurrencyId**: string; amount: number (0) | `{"baseCurrencyId": "btc-bitcoin", "quoteCurrencyId": "usd", "amount": 1}` |
 | search | Search currencies, exchanges, icos, people, tags | **q**: string; categories: string; modifier: string; limit: number (50) | `{"q": "btc", "categories": "currencies,exchanges", "modifier": "symbol", "limit": 5}` |
+| status | API health check | none | `{}` |
+| getCapabilities | Agent onboarding notes for this server | none | `{}` |
+| resolveId | Resolve a name or symbol to a canonical ID | **type**: string; **query**: string; limit: number | `{"type": "coin", "query": "bitcoin", "limit": 5}` |
+| getCoinOHLCVLatest | OHLCV for the last full day | **coinId**: string; quote: string | `{"coinId": "btc-bitcoin", "quote": "usd"}` |
+| getCoinOHLCVToday | OHLCV for the current day | **coinId**: string; quote: string | `{"coinId": "btc-bitcoin", "quote": "usd"}` |
+| getCoinOHLCVHistorical | Historical OHLCV | **coinId**: string; **start**: string; end: string; limit: number; interval: string; quote: string | `{"coinId": "btc-bitcoin", "start": "2026-07-01", "interval": "24h"}` |
+| getTickersHistoricalById | Historical ticks for a coin | **coinId**: string; **start**: string; end: string; limit: number; quote: string; interval: string | `{"coinId": "btc-bitcoin", "start": "2026-07-01", "interval": "1d"}` |
+| getHistoricalTickerByContract | Historical ticks by contract address | **platformId**: string; **contractAddress**: string; **start**: string; end: string; limit: number; quote: string; interval: string | `{"platformId": "eth-ethereum", "contractAddress": "0x...", "start": "2026-07-01"}` |
+| keyInfo | API key plan and monthly usage | none | `{}` |
+| getMappings | Map other providers' IDs to CoinPaprika IDs | coinpaprika: string; coinmarketcap: string; coingecko: string; cryptocompare: string; isin: string; dti: string | `{"coingecko": "bitcoin"}` |
+| getChangelogIDs | Coin ID changes made by moderators | page: number; limit: number | `{"page": 1, "limit": 50}` |
+| submitFeedback | Report a gap or problem with this server | **goal**: string; attempted_tools: string; blocked_at: string; expected: string; observed: string; severity: string | `{"goal": "Fetch hourly OHLCV", "observed": "402 returned"}` |
+
+<Note>
+  This table is the full set of 31 tools the server exposes. To confirm it against the running
+  server at any time, call `tools/list` as shown above.
+</Note>
 
 ### Call Pattern Template
 


### PR DESCRIPTION
I went through every page on docs.coinpaprika.com against the live API and the live pricing page ahead of the paid-plans launch. These are the things that did not match.

**The rate-limit table in the API reference had the wrong number for every paid plan.** It said Starter 200 000, Pro 500 000, Business 3 000 000. The pricing page at coinpaprika.com/api/pricing says 400 000, 1 000 000 and 5 000 000. It was also missing the Ultimate plan entirely, in both the rate-limit table and the base-URL table, even though Ultimate is a real $1,499/mo plan we sell. A developer sizing a plan off the API reference would have picked the wrong one.

**The TypeScript SDK card linked to a 404.** It pointed at coinpaprika/coinpaprika-api-js-client, which does not exist. The real repo is coinpaprika-api-nodejs-client. While I was there I added the Swift and Kotlin cards, because the FAQ tells people the SDK list is on that page and those two were missing from it.

**The REST getting-started page invented a daily quota.** It said "you can make up to 1,000 requests per day without authentication". There is no daily quota. The free tier is 20 000 calls per month across 2 000 assets, which is what every other page already says.

**The FAQ asset counts were years out of date.** It said "more than 53k assets, of which about 8-10k are active". I pulled /v1/coins today: 60 803 assets, 11 610 of them active. Now it says more than 60 000 and over 11 000.

**The MCP tool count said 29.** I called tools/list on mcp.coinpaprika.com and got 31. The JSON-RPC page also listed only 19 of those 31 in its Available Tools table, so I added the missing twelve with the argument names read off the live schema rather than off a README.

**Nothing on the streaming pages said WebSockets are Enterprise-only.** The pricing page and our own FAQ both say the WebSocket protocol is part of the Enterprise plan, but the streaming introduction and the five-minute tutorial just told people to grab a key from the panel and connect. Anyone on Starter or Pro would have followed that and failed. Both pages now say which plan it needs.

**Em dashes.** House style is no em dashes in published prose. Removed the ones in the index title and headings and in the Swift, Kotlin and Rust SDK pages.

**README.** The clone command pointed at coinpaprika/coinpaprika-api-docs, which 404s, and carried a "replace with the correct repository URL" comment that had clearly been sitting there a while. The paths also still had a documentation/ prefix from an older layout. Fixed both, and dropped the emoji.

I checked openapi.yml and docs.json still parse. One thing I did not touch: the per-endpoint plan lists inside openapi.yml also omit Ultimate, in about eighteen places. Adding it there is a statement about which plans can call which endpoint, so I would rather someone on the product side confirm it than guess.